### PR TITLE
set LINKER_LANGUAGE CXX for ref-cmake

### DIFF
--- a/deps/ref-cmake/CMakeLists.txt
+++ b/deps/ref-cmake/CMakeLists.txt
@@ -22,4 +22,5 @@ set_target_properties(
   ref
   PROPERTIES
   PREFIX "" 
-  SUFFIX ".node")
+  SUFFIX ".node"
+  LINKER_LANGUAGE CXX)


### PR DESCRIPTION
Was running into this issue for linux build testing:

https://stackoverflow.com/questions/11801186/cmake-unable-to-determine-linker-language-with-c