### PR TITLE
Make sure Visual Studio 2017 can find nan.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ include_directories(
     ${DYNLOAD_INCLUDE_DIRS}
     ${CMAKE_JS_INC}
     "${CMAKE_SOURCE_DIR}/deps/optional"
-    "${CMAKE_SOURCE_DIR}/src")
+    "${CMAKE_SOURCE_DIR}/src"
+    "../nan")
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 


### PR DESCRIPTION
This is only needed when `npm init` wasn't called. I don't know if you want to support that case